### PR TITLE
add compatibility for macos : lib byteswap.h not present on Macos so …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,17 @@
 CC=gcc
 SRCS=dxr.c dxr_png.c
 
+FLAGS = -Wall -Wextra -Werror
+OS_NAME := $(shell uname)
+ifeq ($(OS_NAME),Darwin)
+	FLAGS += -D __MAC__
+endif
+
+
 all: dxr2png
 
 dxr2png: $(SRCS)
-	$(CC) -W -Wall -Wextra -o $(@) $(SRCS) -lpng
+	$(CC) $(FLAGS) -o $(@) $(SRCS) -lpng
 
 clean:
 	rm -fv dxr2png *.c~

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,6 @@
 CC=gcc
 SRCS=dxr.c dxr_png.c
-
 FLAGS = -Wall -Wextra -Werror
-OS_NAME := $(shell uname)
-ifeq ($(OS_NAME),Darwin)
-	FLAGS += -D __MAC__
-endif
-
 
 all: dxr2png
 

--- a/dxr.c
+++ b/dxr.c
@@ -7,7 +7,11 @@
 #include <string.h>
 //#include <strings.h>
 #include <assert.h>
-#include <byteswap.h>
+#ifdef __MAC__
+	#include <libkern/OSByteOrder.h>
+#else
+	#include <byteswap.h>
+#endif
 
 #include <png.h>
 
@@ -243,8 +247,13 @@ int main(int argc, char*argv[]) {
             b2 = read_pix((off + 1) * precision, precision);
 
             // PNG expect MSB first, and convert to 16-bit
-            b1 = bswap_16(b1 << (16 - hdr.precision));
-            b2 = bswap_16(b2 << (16 - hdr.precision));
+#ifdef __MAC__
+			b1 = OSSwapInt16(b1 << (16 - hdr.precision));
+			b2 = OSSwapInt16(b2 << (16 - hdr.precision));
+#else
+			b1 = bswap_16(b1 << (16 - hdr.precision));
+			b2 = bswap_16(b2 << (16 - hdr.precision));
+#endif
 
 #if 0
             printf("%5d: %d: %02x %02x %02x : %03x %03x\n",

--- a/dxr.c
+++ b/dxr.c
@@ -7,10 +7,10 @@
 #include <string.h>
 //#include <strings.h>
 #include <assert.h>
-#ifdef __MAC__
-	#include <libkern/OSByteOrder.h>
+#ifdef __APPLE__
+#    include <libkern/OSByteOrder.h>
 #else
-	#include <byteswap.h>
+#    include <byteswap.h>
 #endif
 
 #include <png.h>
@@ -247,12 +247,12 @@ int main(int argc, char*argv[]) {
             b2 = read_pix((off + 1) * precision, precision);
 
             // PNG expect MSB first, and convert to 16-bit
-#ifdef __MAC__
-			b1 = OSSwapInt16(b1 << (16 - hdr.precision));
-			b2 = OSSwapInt16(b2 << (16 - hdr.precision));
+#ifdef __APPLE__
+            b1 = OSSwapInt16(b1 << (16 - hdr.precision));
+            b2 = OSSwapInt16(b2 << (16 - hdr.precision));
 #else
-			b1 = bswap_16(b1 << (16 - hdr.precision));
-			b2 = bswap_16(b2 << (16 - hdr.precision));
+            b1 = bswap_16(b1 << (16 - hdr.precision));
+            b2 = bswap_16(b2 << (16 - hdr.precision));
 #endif
 
 #if 0


### PR DESCRIPTION
…bswap_16 function is undeclared, solution is to add #include libkern/OSByteOrder.h and replace bswap_16 by OSSwapInt16